### PR TITLE
Fix incorrect host module usage documentation

### DIFF
--- a/modules/host/README.md
+++ b/modules/host/README.md
@@ -13,7 +13,7 @@ module "zone" {
 }
 
 module "host" {
-  source = "github.com/dbalcomb/terraform-azurerm-aks-ingress//modules/host"
+  source = "github.com/dbalcomb/terraform-azurerm-dns//modules/host"
 
   name = "www.example.com"
   zone = module.zone


### PR DESCRIPTION
This fixes a mistake with the usage documentation when migrating the host module from another repository.