### PR TITLE
Fix host module name output

### DIFF
--- a/modules/host/outputs.tf
+++ b/modules/host/outputs.tf
@@ -1,6 +1,6 @@
 output "name" {
   description = "The host name"
-  value       = var.name
+  value       = trimsuffix(azurerm_dns_a_record.main.fqdn, ".")
 }
 
 output "zone" {


### PR DESCRIPTION
This fixes an undocumented feature of the `host` module that supports passing an empty string or subdomain as the input name. This caused the output name to be the same as the input which would not be the actual full hostname including the zone name. This changes the output to use the fully qualified domain name from the `azurerm_dns_a_record` resource without the trailing dot.